### PR TITLE
fix: package visibility and workflow versioning

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm ci
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
@@ -45,7 +45,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6.2.0
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furkankoykiran/omniwire-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Gold standard MCP data flow server with Sentinel architecture, dynamic configuration, and universal parsing",
   "type": "module",
   "main": "dist/index.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/furkankoykiran/OmniWire-MCP.git"
+    "url": "git+https://github.com/furkankoykiran/OmniWire-MCP.git"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This PR addresses the issues with GitHub Packages visibility and workflow failures by:
1. Updating `repository.url` in `package.json` to include the `git+` prefix.
2. Fixing the invalid `actions/setup-node` version in `.github/workflows/npm-publish.yml` (from `v6.2.0` to `v4`).
3. Bumping version to `1.0.5`.

These changes were identified by comparing with the working `DevTo-MCP` repository.