### PR TITLE
fix: provenance issues on GitHub Packages publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furkankoykiran/omniwire-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Gold standard MCP data flow server with Sentinel architecture, dynamic configuration, and universal parsing",
   "type": "module",
   "main": "dist/index.js",
@@ -12,8 +12,7 @@
     "url": "git+https://github.com/furkankoykiran/OmniWire-MCP.git"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "files": [
     "dist"


### PR DESCRIPTION
This PR fixes the `EUSAGE` error in the `publish-gpr` job (GitHub Packages) which was caused by attempting to generate provenance without the necessary `id-token: write` permission.

Changes:
1. Removed `"provenance": true` from `package.json`.
2. Added `--provenance` flag specifically to the `publish-npm` job in `.github/workflows/npm-publish.yml`.
3. Bumping version to `1.0.6`.

This aligns `OmniWire-MCP` with the working configuration in `DevTo-MCP`.