### PR TITLE
fix: provenance issues on GitHub Packages publish (v2)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furkankoykiran/omniwire-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Gold standard MCP data flow server with Sentinel architecture, dynamic configuration, and universal parsing",
   "type": "module",
   "main": "dist/index.js",
@@ -12,8 +12,7 @@
     "url": "git+https://github.com/furkankoykiran/OmniWire-MCP.git"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Re-applying the fix for GPR publish failure. Removed provenance from package.json and moved to CLI flag.